### PR TITLE
Rename Home.md to index.md so mkdocs knows where the front page is

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -16,23 +16,23 @@ Here are a few demos of the library in action:
 These pages offer an introduction to the concepts behind Tangram:
 
 - The [Scene File](Scene-file.md)
-- [Filters](Filters-overview.md)  
-- [Lights](Lights-overview.md)  
-- [Cameras](Cameras-overview.md)  
-- [Materials](Materials-overview.md)  
-- [Shaders](Shaders-overview.md)  
-- [Styles](Styles-overview.md)  
+- [Filters](Filters-Overview.md)
+- [Lights](Lights-Overview.md)
+- [Cameras](Cameras-Overview.md)
+- [Materials](Materials-Overview.md)
+- [Shaders](Shaders-Overview.md)
+- [Styles](Styles-Overview.md)
 
 ### Technical Reference
 
 These pages list the objects and parameters of the scene file, as well as their acceptable values.
 
-- [yaml](yaml.md)  
-- [sources](sources.md)  
-- [cameras](cameras.md)  
-- [lights](lights.md)   
-- [materials](materials.md)  
-- [styles](styles.md)  
-- [layers](layers.md)  
-- [draw](draw.md)  
-- [shaders](shaders.md)  
+- [yaml](yaml.md)
+- [sources](sources.md)
+- [cameras](cameras.md)
+- [lights](lights.md)
+- [materials](materials.md)
+- [styles](styles.md)
+- [layers](layers.md)
+- [draw](draw.md)
+- [shaders](shaders.md)

--- a/pages/index.md
+++ b/pages/index.md
@@ -28,6 +28,7 @@ These pages offer an introduction to the concepts behind Tangram:
 These pages list the objects and parameters of the scene file, as well as their acceptable values.
 
 - [yaml](yaml.md)
+- [scene](scene.md)
 - [sources](sources.md)
 - [cameras](cameras.md)
 - [lights](lights.md)


### PR DESCRIPTION
MkDocs requires the front page be named index.md. Since that's what Home.md is intended to be (as far as I understand) I propose renaming that file here in the repository, which would make the import pipeline much easier.

(See second bullet point in the lower half of the first post in issue #24.)

Some additional changes:
- Add in reference to scene.yaml (it's in README.md but wasn't in Home.md)
- Fix file name capitalization to match what's in the directory.
- Remove trailing whitespace.

Please let me know if you have any concerns or questions about this proposal.
