### PR TITLE
Typo in area filter example, changed code to match the comment

### DIFF
--- a/pages/Filters-Overview.md
+++ b/pages/Filters-Overview.md
@@ -197,7 +197,7 @@ The filter functions `min` and `max` are equivalent to `>=` and `<` in a JavaScr
 
 ```yaml
 filter:
-    area: { max: 10000 } }      # matches areas up to 1000 sq meters
+    area: { max: 1000 } }      # matches areas up to 1000 sq meters
 
 filter:
     height: { min: 70 } }       # matches heights 70 and up


### PR DESCRIPTION
I think this is a typo and should have been 1000 instead of 10000 to match the comment explaining the line in the example.
