### PR TITLE
Clarify 'origin: ground' for lights

### DIFF
--- a/pages/Lights-Overview.md
+++ b/pages/Lights-Overview.md
@@ -124,10 +124,10 @@ Origin can be specified as relative to three different spaces: *world*, *camera*
     ambient: .3
     diffuse: 1.
     specular: .2
-    ``` 
+    ```
 [ ![](images/ex-pointlight-01.png) ](http://tangrams.github.io/tangram-docs/?lights/ex-pointlight-01.yaml)
-   
-- *Ground space* is the same as camera space, but the height of the light is specified relative to the ground:
+
+- In *ground space*, the position is relative to the point on the ground in the center of the current view:
 
     ```yaml
     type: point

--- a/pages/lights.md
+++ b/pages/lights.md
@@ -132,7 +132,7 @@ Sets the reference point for the `position` parameter:
 
 - `world`: sets x and y in _[lat, lng]_ and z in `m` from the ground
 - `camera`: sets x and y in `px` from the camera center, and z in `m` from the camera
-- `ground`: sets x and y in `px` from the camera center, and z in `m` from the ground
+- `ground`: sets x and y in `px` from the point on the ground in the center of the current view, and z in `m` from the ground
 
 ```yaml
 light1:


### PR DESCRIPTION
Positions are relative to the point on the ground in the center of the current view, which is not necessarily the point directly below the camera. This distinction is important for tilted or rotated views, see https://github.com/tangrams/tangram-es/pull/597 for an example. 
