### PR TITLE
Texture definition clarifications and corrections

### DIFF
--- a/pages/Materials-Overview.md
+++ b/pages/Materials-Overview.md
@@ -103,7 +103,7 @@ Material properties can be controlled with pixel-level detail when used with ***
 
 ![](images/earth.png)
 
-Textures are loaded by setting the `texture` parameter to the url of an image:
+Textures are loaded by setting the `texture` parameter to the url of an image or the name of an entry in the [`textures`](textures.md) block:
 
 ```yaml
 material:

--- a/pages/Materials-Overview.md
+++ b/pages/Materials-Overview.md
@@ -50,7 +50,7 @@ stylename:
 ###`specular`
 In our lighting model, "specular" is the "highlight" color of a material. It can be thought of as the reflection of the light source itself on the surface of an object. The `shininess` parameter controls the size of the highlight: larger numbers produce smaller highlights, which makes the object appear shinier.
 
-By default, these are set to `specular: 0` and `shininess: 0.2` 
+By default, these are set to `specular: 0` and `shininess: 0.2`
 
 ```yaml
 lights:
@@ -99,7 +99,7 @@ stylename:
 
 ## Textures
 
-Material properties can be controlled with pixel-level detail when used with ***texture maps***. 
+Material properties can be controlled with pixel-level detail when used with ***texture maps***.
 
 ![](images/earth.png)
 
@@ -112,7 +112,7 @@ material:
 ```
 
 ###Mapping
-When using a texture, you must specify one of four `mapping` modes, which determine the method used to apply the texture to an object. In every case, texture coordinates are applied to the vertices of the geometry, and the image is drawn according to those coordinates. 
+When using a texture, you must specify one of four `mapping` modes, which determine the method used to apply the texture to an object. In every case, texture coordinates are applied to the vertices of the geometry, and the image is drawn according to those coordinates.
 
 ### `mapping: uv`
 UV mapping is related to the size and proportions of the geometry. With this method, a bounding box is applied to contiguous surfaces, and texture coordinates are applied to the corners of the bounding box. In the following example, a grid image is applied to each polygon. On larger shapes, the UVs are tiled, resulting in a tiled image.
@@ -179,7 +179,7 @@ Each `texture` can also have the following properties:
 
 ### Normals
 
-The `normal` of a polygon is a three-dimensional vector describing the direction that it is considered to be facing. The direction that a 3D plane is facing may seem obvious, but most 3D engines allow a polygon's apparent direction to be changed without modifying the geometry, which is useful in many situations. 
+The `normal` of a polygon is a three-dimensional vector describing the direction that it is considered to be facing. The direction that a 3D plane is facing may seem obvious, but most 3D engines allow a polygon's apparent direction to be changed without modifying the geometry, which is useful in many situations.
 
 Tangram's polygon model assigns normals to the vertices at the corners of a polygon when the geometry is constructed, and these values are interpolated across the face of the polygon to calculate the normal at any given point. This information is used as part of the diffuse and specular lighting calculations.
 

--- a/pages/draw.md
+++ b/pages/draw.md
@@ -590,13 +590,6 @@ draw:
             tile_edges: true
 ```
 
-####`texture`
-Optional _block_ or _URL_. As a _block_, defines the start of an inline `texture` block. As a _URL_, defines the file path of an image to be used as a texture.
-
-May be applied to _polygons_, _points_, or _lines_ styles.
-
-See the top-level [`textures`](textures.md) object for more.
-
 ####`transition`
 [[ES-only](https://github.com/tangrams/tangram-es)] Optional _map_ , where key is one or both of `hide` and `show` and value is a _map_ of `time` to time. `time` values can be either in seconds (`s`) or milliseconds (`ms`).
 

--- a/pages/materials.md
+++ b/pages/materials.md
@@ -89,7 +89,7 @@ material:
 
 #### `texture`
 
-Optional _named texture_, _URL_, or _texture object_. No default.
+Optional _named texture_ or _URL_. No default.
 
 For more, see [textures#texture](textures.md#texture).
 

--- a/pages/materials.md
+++ b/pages/materials.md
@@ -26,11 +26,11 @@ styles:
     red-wall:
         base: polygons
         material:
-            diffuse: red 
+            diffuse: red
 ```
 
 
-#### `ambient` 
+#### `ambient`
 Optional parameter. Can be a _number_ from `0`-`1`, `[R, G, B]`, `hex-color`, `css color name`, or _texture_. Defaults to the `diffuse` value.
 
 ```yaml
@@ -133,6 +133,6 @@ material:
         mapping: uv
         scale: 2.0
         amount: 0.5
-``` 
+```
 
 See also: [texture parameters](textures.md#texture-parameters).

--- a/pages/textures.md
+++ b/pages/textures.md
@@ -33,7 +33,7 @@ styles:
 
 A _texture object_ may also be defined inline, anywhere a `texture` parameter may be specified:
 ```yaml
-# defining a texture 
+# defining a texture
 styles:
     rock:
         base: polygons
@@ -136,7 +136,7 @@ Optional parameter. Defines the start of a `sprites` block.
 #### sprite name
 Required _string_. Can be anything. No default.
 
-Defines an area of a texture to be used as an individual sprite, as _[x origin, y origin, width, height]_ in pixels. 
+Defines an area of a texture to be used as an individual sprite, as _[x origin, y origin, width, height]_ in pixels.
 
 ```yaml
 pois:

--- a/pages/textures.md
+++ b/pages/textures.md
@@ -11,12 +11,7 @@ textures:
         url: demos/images/brick.jpg
 ```
 
-####`texture`
-Optional _named texture, _URL_, or _texture object_. No default.
-
-A _texture object_ may be defined either in the top-level `textures` element or inline.
-
-When defined in the top-level `textures` element, it is declared as a _texture name_ which allows it to be referenced by name in other `texture` parameters, including in `styles` and `materials` definitions:
+When a texture is defined in the top-level `textures` element, it is declared with a _texture name_ which allows it to be referenced by name in other `texture` parameters, including in `styles` and `materials` definitions:
 
 ```yaml
 # here we define and name the texture
@@ -31,47 +26,20 @@ styles:
         texture: pois
 ```
 
-A _texture object_ may also be defined inline, anywhere a `texture` parameter may be specified:
+Outside of the `textures` element, a new texture may be defined inline by providing a URL instead of a texture name:
 ```yaml
-# defining a texture
+# defining a new texture inline
 styles:
     rock:
         base: polygons
         material:
             normal:
-                texture:
-                    url: rock.jpg
+                texture: images/rock.jpg
                 mapping: uv
 ```
+These textures will use the default [parameters](#texture parameters) described below. To use custom parameters for a texture, you must declare it in the `textures` element.
 
-```yaml
-# defining a texture inline in the texture parameter of a style based on points
-styles:
-    animals-style:
-        base: points
-        texture:
-            url: path/to/image.png
-            filtering: mipmap
-            sprites:
-                bunny: [0, 0, 32, 32]
-                fox: [0, 32, 32, 32]
-```
-
-Whether defined in the `textures` element or inline, at a minimum, a `URL` or `element` must be passed:
-
-```yaml
-textures:
-    ghost:
-        url: images/ghost.png
-```
-
-```yaml
-styles:
-    points:
-        texture: images/ghost.png
-```
-
-If provided for a _lines_ style, the texture is repeated across the line, with the width of the texture matching the width of the line, and the texture y coordinate scaled to match the aspect ratio of the image (its height over its width).
+If a texture is provided for a _lines_ style, the texture is repeated across the line, with the width of the texture matching the width of the line, and the texture y coordinate scaled to match the aspect ratio of the image (its height over its width).
 
 ## texture parameters
 


### PR DESCRIPTION
This is my understanding of the ways that textures can be defined in a scene based on the behavior of the current version of tangram. Some of this is due to recent changes (https://github.com/tangrams/tangram/commit/18d79786c4d3fccc24be967a6058d2fdb74c04b1). 
- Material components can use either a named scene texture or a URL-only texture definition
- 'inline' texture definitions can only use the URL-only definition form
- 'texture' is not a parameter of draw groups
