### PR TITLE
Deprecate `move_into_tile`

### DIFF
--- a/pages/Styles-Overview.md
+++ b/pages/Styles-Overview.md
@@ -143,7 +143,6 @@ Styles which are extensions of the `text` style can take the following special p
 - [`repeat_distance`](draw.md#repeat_distance): Sets the distance beyond which label text may repeat.
 - [`repeat_group`](draw.md#repeat_group): Optional grouping mechanism for fine-grained control over text repetition.
 - [`collide`](draw.md#collide): Sets whether label collides with other labels or points/sprites.
-- [`move_into_tile`](draw.md#move_into_tile): Increases number of labels that will display, by moving some to fit within tile bounds (JS-only)
 
 These parameters are described in the [draw](draw.md) entry.
 

--- a/pages/draw.md
+++ b/pages/draw.md
@@ -277,11 +277,6 @@ draw:
       miter_limit: 2
 ```
 
-####`move_into_tile`
-[[JS-only](https://github.com/tangrams/tangram)] Optional _boolean_. Default is _true_.
-
-Applies to `text` styles. Moves the label into the tile if the label would otherwise cross a tile boundary. This should be set to _false_ if using `anchor`/`align` functionality for text + icon combinations – otherwise, text can get out of sync with expected position.
-
 ####`offset`
 Optional _[float x, float y]_ _array_ or _stops_, in `px`. No default.
 


### PR DESCRIPTION
To be merged with Tangram JS v0.11.0, see https://github.com/tangrams/tangram/pull/411.
