### PR TITLE
update vector and terrain tile urls

### DIFF
--- a/pages/Filters-Overview.md
+++ b/pages/Filters-Overview.md
@@ -2,7 +2,7 @@ Tangram is designed to work with vector tiles in a number of formats. Data sourc
 
 The Tangram scene file filters data in two ways: with top-level **layer filters** and lower-level **feature filters**.
 
-## Layer filters
+# Layer filters
 
 Vector tiles typically contain top-level structures which can be thought of as "layers" – inside a GeoJSON file, these would be the _FeatureCollection_ objects. Inside a Tangram scene file, the [`layers`](layers.md) object allows you to split the data by layer, by matching against the layer name.
 
@@ -25,7 +25,7 @@ Specifying `layer: roads` in the [`data`](layers.md#data) block matches this Geo
 }
 ```
 
-#### Layer name shortcut
+## Layer name shortcut
 
 If a `layer` filter is not specified, Tangram will attempt to use the _layer name_ as the filter. In this example, the layer name "roads" matches a layer in the data:
 
@@ -37,7 +37,7 @@ layers:
         draw: ...
 ```
 
-## Feature filters
+# Feature filters
 
 Once a top-level `layer` filter has been applied, feature-level [`filter`](layers.md#filter) objects can be defined to filter by feature properties, in order to further narrow down the data of interest and refine the styles applied to the data.
 
@@ -56,19 +56,19 @@ Here, a top-level layer named "roads" matches the "roads" layer in the "osm" dat
 
 Then, a _sublayer_ named "highway" is declared, with its own `filter` and `draw`. Its `draw` block will apply only to roads which match its `filter` – in this case, those with the property "kind", with a value of "highway".
 
-#### Inheritance
+## Inheritance
 
 Higher-level filters continue to apply at lower levels, which means that higher-level `draw` parameters will be inherited by lower levels, unless the lower level explicitly overrides it.
 
 Using sublayers and inheritance, you may specify increasingly specific filters and draw styles to account for as many special cases as you like.
 
-## Matching
+# Matching
 
 Each feature in a `layer` is first tested against each top-level `filter`, and if the feature's data matches the filter, that feature will be assigned any associated [`draw`](draw.md) styles, and passed on to any _sublayers_. If any _sublayer_ filters match the feature, that _sublayer_'s `draw` styles will overwrite any previously-assigned styling rules for those matching features, and so on down the chain of inheritance.
 
 Feature filters can match any named feature property in the data, as well as a few special _reserved keywords_.
 
-#### Feature properties
+## Feature properties
 
 Feature properties in a GeoJSON datasource are listed in a JSON member specifically named "properties":
 
@@ -82,6 +82,7 @@ Feature properties in a GeoJSON datasource are listed in a JSON member specifica
         "height": 63.4000000
     }
 ```
+
 Analogous property structures exist in other data formats such as TopoJSON and Mapbox Vector Tiles. Tangram makes these structures available to `filter` blocks by property name, and also to any JavaScript filter functions under the `feature` keyword.
 
 The json feature above will match these two filters:
@@ -96,32 +97,43 @@ filter: function() { return feature.kind == "commercial"; }
 The simplest type of feature filter is a statement about one named property of a feature.
 
 A filter can match an exact value:
+
 ```yaml
 filter:
     kind: residential
 ```
+
 any value in a list:
+
 ```yaml
 filter:
     kind: [residential, commercial]
 ```
+
 or a value in a numeric range:
+
 ```yaml
 filter:
     area: { min: 100, max: 500 }
 ```
+
 A Boolean value of "true" will pass a feature that contains the named property, ignoring the property's value. A value of "false" will pass a feature that does _not_ contain the named property:
+
 ```yaml
 filter:
     kind: true
     area: false
 ```
+
 To match a property whose value is a boolean, use the list syntax:
+
 ```yaml
 filter:
     boolean_property: [true]
 ```
+
 A feature filter can also evaluate one or more properties in a JavaScript function:
+
 ```yaml
 filter:
     function() { return feature.area > 100000 }
@@ -155,7 +167,7 @@ filter: function() { return feature.height <= 100; }
 filter: function() { return false; }
 ```
 
-#### Keyword properties
+## Keyword properties
 
 The keyword `$geometry` matches the feature's geometry type, for cases when a FeatureCollection includes more than one type of kind of geometry. Valid geometry types are:
 
@@ -197,7 +209,7 @@ filter:
 filter: function() { return $zoom <= 10 }   # matches zooms 10 and below
 ```
 
-#### `label_placement`
+## `label_placement`
 
 The `label_placement` property is given only to special auto-generated _point_ geometries, and may be used for placing a single label in the center of a polygon, instead of once per tile. To add these _points_ to a datasource, add the `generate_label_centroids` property to its [source] block:
 
@@ -205,7 +217,7 @@ The `label_placement` property is given only to special auto-generated _point_ g
 sources:
     mapzen:
         type: TopoJSON
-        url:  https://vector.mapzen.com/osm/all/{z}/{x}/{y}.topojson
+        url:  https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.topojson
         generate_label_centroids: true
 
 layers:
@@ -218,9 +230,9 @@ layers:
 
 See [`generate_label_centroids`](sources.md#generate_label_centroids)
 
-#### Filter functions
+## Filter functions
 
-##### Range functions
+### Range functions
 
 The filter functions `min` and `max` are equivalent to `>=` and `<` in a JavaScript function, and can be used in combination.
 
@@ -235,7 +247,8 @@ filter:
     $zoom: { min: 5, max: 10 }  # matches zooms 5-9
 ```
 
-##### `px2`
+### `px2`
+
 Range functions can also accept a special screen-space area unit called `px2`:
 
 ```yaml
@@ -250,7 +263,7 @@ The `px2` unit syntax can be used to simplify more cumbersome per-zoom filters.
 
 Note that a `px2` area filter can only be applied if the data source already contains a suitable area property – it does not need to be named area, as any property name can be specified in the filter, but it must already exist in the data source.
 
-##### Boolean functions
+### Boolean functions
 
 The following Boolean filter functions are also available:
 
@@ -269,7 +282,7 @@ filter:
     not: { kind: [bar, pub] }
 ```
 
- `any`, `all`, and `none` take lists of filter objects:
+`any`, `all`, and `none` take lists of filter objects:
 
 ```yaml
 filter:
@@ -289,7 +302,7 @@ filter:
         - { kind: aerodrome }
 ```
 
-#### Lists imply `any`, Mappings imply `all`
+## Lists imply `any`, Mappings imply `all`
 
 A _list_ of several filters is a shortcut for using the `any` function. These two filters are equivalent:
 
@@ -313,7 +326,7 @@ filter:
         - $zoom: { min: 13 }
 ```
 
-#### Matching collisions
+## Matching collisions
 
 In some cases, filters at the same level may return overlapping results:
 
@@ -328,7 +341,7 @@ roads:
         draw: { lines: { color: blue } }
 ```
 
-In this case, "highways" are colored red, and "bridges" are blue. However, if any feature is both a "highway" *and* a "bridge", it will match twice. Because YAML maps are technically "orderless", there's no way to guarantee that one of these styles will consistently be shown over the other. The solution here is to restructure the styles so that each case matches explicitly:
+In this case, "highways" are colored red, and "bridges" are blue. However, if any feature is both a "highway" _and_ a "bridge", it will match twice. Because YAML maps are technically "orderless", there's no way to guarantee that one of these styles will consistently be shown over the other. The solution here is to restructure the styles so that each case matches explicitly:
 
 ```yaml
 roads:

--- a/pages/Javascript-API.md
+++ b/pages/Javascript-API.md
@@ -100,7 +100,7 @@ Loads a new `source` object (see [`sources`](sources.md)), returning a Promise w
 If `name` doesn't match an existing source, a new source object will be created. The `source` object must follow the [`sources`](sources.md#sources) specification.
 
 ```javascript
-scene.setDataSource('osm', { type: 'TopoJSON', url: 'https://vector.mapzen.com/osm/all/{z}/{x}/{y}.topojson' });
+scene.setDataSource('osm', { type: 'TopoJSON', url: 'https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.topojson' });
 ```
 
 ```javascript

--- a/pages/Raster-Overview.md
+++ b/pages/Raster-Overview.md
@@ -57,7 +57,7 @@ sources:
         url: http://a.tile.stamen.com/terrain-background/{z}/{x}/{y}.jpg
     mapzen-osm:
         type: TopoJSON
-        url: https://vector.mapzen.com/osm/all/{z}/{x}/{y}.topojson
+        url: https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.topojson
         rasters: [stamen-terrain] # attach stamen terrain
 
 layers:
@@ -122,10 +122,11 @@ This example loads pre-computed "normal" tiles as a normal map, which can be lit
 sources:
     terrain-normals:
         type: Raster
-        url: https://terrain-preview.mapzen.com/normal/{z}/{x}/{y}.png
+        url: https://tile.mapzen.com/mapzen/terrain/v1/normal/{z}/{x}/{y}.png
+
     mapzen-osm:
         type: TopoJSON
-        url: https://vector.mapzen.com/osm/all/{z}/{x}/{y}.topojson
+        url: https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.topojson
         rasters: [terrain-normals]
 
 styles:
@@ -159,7 +160,7 @@ styles:
     elevation:
         base: polygons
         raster: custom
-        shaders: 
+        shaders:
             blocks:
                 global: |
                     // Unpack RGB elevation
@@ -208,4 +209,3 @@ layers:
 ```
 
 ![tangram-wed mar 30 2016 17-20-15 gmt-0400 edt](https://cloud.githubusercontent.com/assets/16733/14158040/074abc0e-f69c-11e5-9cc5-a2852f24b46d.png)
-

--- a/pages/Scene-file.md
+++ b/pages/Scene-file.md
@@ -57,13 +57,13 @@ To create a map, the scene file requires only:
 - data interpretation rules (filters)
 - styling rules
 
-Here's a very simple scene file:
+Here's a simple scene file:
 
 ```yaml
 sources:
     mapzen:
         type: TopoJSON
-        url: https://vector.mapzen.com/osm/all/{z}/{x}/{y}.topojson
+        url: https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.topojson
 
 layers:
     earth:
@@ -75,22 +75,17 @@ layers:
     water:
         data: { source: mapzen }
         draw:
-            polygons: 
+            polygons:
                 order: 1
                 color: lightblue
 
     roads:
         data: { source: mapzen }
         draw:
-            lines: 
+            lines:
                 order: 2
                 color: white
                 width: 1.5px
 ```
 
-In this example, all three elements are included – this will produce a (very simple) map!
-
-## Examples
-For more examples of scene files, check out our [demos](https://github.com/tangrams?query=demo) – ours are usually named `scene.yaml`.
-
-For even more amazing examples, check out the [Tangram Sandbox](http://tangrams.github.io/tangram-sandbox/)!
+In this example, all three elements are included – this will produce a map.

--- a/pages/android-walkthrough.md
+++ b/pages/android-walkthrough.md
@@ -63,7 +63,7 @@ Mapzen provides a free vector tile service with GeoJSON, TopoJSON, and MVT tiles
 sources:
   mapzen:
     type: MVT
-    url:  https://vector.mapzen.com/osm/all/{z}/{x}/{y}.mvt
+    url:  https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.mvt
     url_params:
       api_key: [YOUR API KEY HERE]
 ```
@@ -77,4 +77,3 @@ In this guide, you learned how to add a Tangram map to your Android application.
  - Learn how to write or edit a Tangram [scene file](https://mapzen.com/documentation/tangram/Scene-file/),
  - See [more examples](https://github.com/tangrams/tangram-android-demos) of things your application can do with the map, or
  - Look at the [reference documentation](https://mapzen.com/documentation/tangram/android-sdk/0.2.1/) for the Tangram Android SDK.
-

--- a/pages/sources.md
+++ b/pages/sources.md
@@ -8,22 +8,22 @@ sources:
     # Mapzen tiles in TopoJSON format
     mapzen-topojson:
         type: TopoJSON
-        url: https://vector.mapzen.com/osm/all/{z}/{x}/{y}.topojson
+        url: https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.topojson
 
     # Mapzen tiles in GeoJSON format
     mapzen-geojson:
         type: GeoJSON
-        url: https://vector.mapzen.com/osm/all/{z}/{x}/{y}.json
+        url: https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.json
 
     # Mapzen tiles in Mapbox Vector Tile format
     mapzen-mvt:
         type: MVT
-        url: https://vector.mapzen.com/osm/all/{z}/{x}/{y}.mvt
+        url: https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.mvt
 
-    # Stamen's terrain tiles
-    stamen-terrain:
+    # Mapzen terrain tiles
+    mapzen-terrain:
         type: Raster
-        url: http://a.tile.stamen.com/terrain-background/{z}/{x}/{y}.jpg
+        url: https://tile.mapzen.com/mapzen/terrain/v1/normal/{z}/{x}/{y}.png
 ```
 
 All of our demos were created using the [Mapzen Vector Tiles](https://github.com/mapzen/vector-datasource) service, which hosts tiled [OpenStreetMap](http://openstreetmap.org) data.
@@ -33,12 +33,12 @@ Required _string_, can be anything. No default.
 
 Specifies the beginning of a source block.
 
-The source below is named `osm`:
+The source below is named `mapzen`:
 ```yaml
 sources:
     mapzen:
         type: GeoJSON
-        url: https://vector.mapzen.com/osm/all/{z}/{x}/{y}.json
+        url: https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.json
 ```
 
 ### required source parameters
@@ -65,7 +65,7 @@ Required _string_. Specifies the source's _URL_. No default.
 sources:
     mapzen:
         type: MVT
-        url: https://vector.mapzen.com/osm/all/{z}/{x}/{y}.mvt
+        url: https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.mvt
 ```
 
 The URL to a tiled datasource will include special tokens ("{x}", "{z}", etc.) which will be automatically replaced with the appropriate position and zoom coordinates to fetch the correct tile at a given point. Use of `https://` (SSL) is recommended when possible, to avoid browser security warnings: in cases where the page hosting the map is loaded securely via `https://`, most browsers require other resources including tiles to be as well).
@@ -95,10 +95,10 @@ Depending on the datasource, you may be able to request specific layers from the
 
 ```yaml
 # all layers
-https://vector.mapzen.com/osm/all/{z}/{x}/{y}.json
+https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.json
 
 # building layer only
-https://vector.mapzen.com/osm/buildings/{z}/{x}/{y}.json
+https://tile.mapzen.com/mapzen/vector/v1/buildings/{z}/{x}/{y}.topojson
 ```
 
 ##### curly braces
@@ -107,7 +107,7 @@ When tiles are requested, Tangram will parse the datasource url and interpret it
 ```yaml
 mapzen:
     type: TopoJSON
-    url: https://vector.mapzen.com/osm/all/{z}/{x}/{y}.topojson
+    url: https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.topojson
 ```
 
 In the example above, Tangram will automatically replace `{x}`, `{y}`, and `{z}` with the correct tile coordinates and zoom level for each tile, depending on which tiles are visible in the current scene, and the result will be something like:
@@ -134,7 +134,7 @@ The `bounds` of a data source are specified as a single, flattened 4-element arr
 sources:
     mapzen:    
         type: TopoJSON
-        url: https://vector.mapzen.com/osm/all/{z}/{x}/{y}.topojson
+        url: https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.topojson
         bounds: [-74.1274, 40.5780, -73.8004, 40.8253] # [w, s, e, n]
 ```
 
@@ -200,7 +200,7 @@ If the feature in question is a multipolygon, the centroid _point_ will be added
 sources:
     local:
         type: GeoJSON
-        url: https://vector.mapzen.com/osm/all/{z}/{x}/{y}.json
+        url: https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.json
         max_zoom: 15
         generate_label_centroids: true
 ```
@@ -214,7 +214,7 @@ Optional _integer_. No default.
 sources:
     local:
         type: GeoJSON
-        url: https://vector.mapzen.com/osm/all/{z}/{x}/{y}.json
+        url: https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.json
         max_display_zoom: 9
         max_display_zoom: 18
 ```
@@ -228,7 +228,7 @@ Sets the highest zoom level which will be requested from the datasource. At high
 sources:
     local:
         type: GeoJSON
-        url: https://vector.mapzen.com/osm/all/{z}/{x}/{y}.json
+        url: https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.json
         max_zoom: 15
 ```
 
@@ -242,7 +242,10 @@ Attaching a `Raster` to another `source` makes that `Raster` available to any sh
 **Note:** a simple _string_ value will not function correctly – even a single `raster` must be in _list_ format, e.g. surrounded by square brackets:
 
 ```yaml
-rasters: [stamen-terrain]
+sources:
+  terrain-normals:
+      type: Raster
+      url: https://tile.mapzen.com/mapzen/terrain/v1/normal/{z}/{x}/{y}.png
 ```
 
 When a `Raster` source itself has additional raster sources set in the `rasters` property, the "parent" source will be the first raster sampler, and those from `rasters` will be added afterward. (essentially it is as if the parent source was inserted as the first item in the rasters array).
@@ -252,7 +255,7 @@ For more, see the [Raster Overview](Raster-Overview.md).
 ####`transform`
 [[JS-only](https://github.com/tangrams/tangram)] Optional _function_.
 
-This allows the data to be manipulated *after* it is loaded but *before* it is styled. Transform functions are useful for custom post-processing, either where you may not have direct control over the source data, or where you have a dynamic manipulation you would like to perform that incorporates other data separate from the source. The `transform` function is passed a `data` object, with a GeoJSON FeatureCollection assigned to each layer name, e.g. `data.buildings` would provide data from the `buildings` layer, with individual features accessible in `data.buildings.features`. 
+This allows the data to be manipulated *after* it is loaded but *before* it is styled. Transform functions are useful for custom post-processing, either where you may not have direct control over the source data, or where you have a dynamic manipulation you would like to perform that incorporates other data separate from the source. The `transform` function is passed a `data` object, with a GeoJSON FeatureCollection assigned to each layer name, e.g. `data.buildings` would provide data from the `buildings` layer, with individual features accessible in `data.buildings.features`.
 
 The `transform` function is supported for all tiled and untiled GeoJSON, TopoJSON, and MVT data sources.
 
@@ -279,7 +282,7 @@ The `url_params` block can contain any number of key-value pairs which will be a
 ```yaml
 sources:
     vector-tiles:
-        url: https://vector.mapzen.com/osm/all/{z}/{x}/{y}.topojson
+        url: https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.topojson
         url_params:
             api_key: vector-tiles-h2UV1dw
 ```

--- a/pages/walkthrough.md
+++ b/pages/walkthrough.md
@@ -221,7 +221,7 @@ This map uses Mapzen's vector tile service for the data. If you want to put this
 3. Copy the text of the key to your clipboard. It should take the form of `vector-tiles-` and some additional characters.
 4. Open the scene.yaml file.
 5. In the `sources:` block, paste your key after the equals sign in
- `https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.topojson?api_key=<vector-tiles-xxxxxxx>`.
+ `https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.topojson`.
 6. Commit the change to the gh-pages branch.
 
 ###Summary and next steps


### PR DESCRIPTION
I found a lot of old vector/terrain tile URLs that need to be updated. Those are updated in here as well as changing the Stamen raster demos to our own. Also got rid of '&api_key=mapzen-xxxxxx' as we've discussed only having that in the documentation overview page. 

I cleaned up some of the formatting on Filters-Overview as well.