### PR TITLE
size can take 2D values also in stops

### DIFF
--- a/pages/draw.md
+++ b/pages/draw.md
@@ -487,7 +487,7 @@ When `true`, stipulates that any _text_ attached to a _point_ must draw with the
 Note that attached _text_ will never draw without its _point_.
 
 ####`size`
-Optional _number_, in `px` or _stops_. Default is `32px`.
+Optional _number_, in `px` or _[x, y]_ in `px` or _stops_ having both 1D or 2D values. Default is `32px`.
 
 Applies to `points`.
 
@@ -502,6 +502,13 @@ draw:
 draw:
     points:
         size: [[13, 64px], [16, 18px], [18, 22px]]
+        sprite: highway
+```
+
+```yaml
+draw:
+    points:
+        size: [[13, [64px, 64px]], [16, [18px, 18px]], [18, [22px,22px]]]
         sprite: highway
 ```
 


### PR DESCRIPTION
Size can take 2D values. Also can take 2D values in stops.

Question can they have mixed 1D and 2D values in stops, example:

`size: [[13, 64px], [16, [18px, 18px]], [18, 22px]]`