### PR TITLE
add link to setup guides

### DIFF
--- a/pages/Tangram-Overview.md
+++ b/pages/Tangram-Overview.md
@@ -137,6 +137,11 @@ For example, with Tangram-JS:
 Tangram will unpack the zip internally, expecting only a single .yaml file to be in the zip's root, which it will use as the scene file. Any other bundled .yaml files (eg [basemaps](https://mapzen.com/blog/introducing-refill-cinnabar-and-zinc-styles-for-tangram/) or [blocks](https://github.com/tangrams/blocks) included with the [import](import.md) block) must therefore be in subdirectories, and all paths in the .yaml file must be relative to this root scene file.
 
 
+## Getting Started
+
+Check out our [Tangram Setup Guides](Tangram-Setup.md) for more information about getting started with your Tangram installation.
+
+
 ## Contributing
 
 Questions? Suggestions? Typos? Bug fixes? We welcome contributions, either to the libraries or to the documentation itself. Learn more at the links below:


### PR DESCRIPTION
To be merged after https://github.com/mapzen/documentation/pull/268 .