### PR TITLE
Remove extra back-tick to fix formating

### DIFF
--- a/pages/yaml.md
+++ b/pages/yaml.md
@@ -50,7 +50,7 @@ Note: YAML key names can't start with a number.
 ```yaml
 sources:
     1860: # THIS WON'T WORK
-````
+```
 
 ## object syntax
 


### PR DESCRIPTION
See screenshot from https://mapzen.com/documentation/tangram/yaml/
<img width="823" alt="yaml_-_tangram" src="https://cloud.githubusercontent.com/assets/366320/26336053/03ce7cbe-3f25-11e7-8fae-fd5c77d66a70.png">

