### PR TITLE
fix min/max_display_zoom typo

### DIFF
--- a/pages/sources.md
+++ b/pages/sources.md
@@ -244,7 +244,7 @@ sources:
     local:
         type: GeoJSON
         url: https://tile.mapzen.com/mapzen/vector/v1/all/{z}/{x}/{y}.json
-        max_display_zoom: 9
+        min_display_zoom: 9
         max_display_zoom: 18
 ```
 


### PR DESCRIPTION
Fix typo on https://mapzen.com/documentation/tangram/sources/
![sources_-_tangram](https://cloud.githubusercontent.com/assets/366320/26771993/9f94afc2-4977-11e7-8f5a-5470b9584a60.png)

