### PR TITLE
Add information about MBTiles sources

### DIFF
--- a/pages/sources.md
+++ b/pages/sources.md
@@ -141,6 +141,21 @@ mapbox:
     url: https://a.tiles.mapbox.com/v4/mapbox.mapbox-streets-v6-dev/{z}/{x}/{y}.vector.pbf?access_token=...
 ```
 
+##### MBTiles
+
+[[ES-only](https://github.com/tangrams/tangram-es)] If the _URL_ of a data source has a file extension of `.mbtiles` then the specified file will be accessed as an MBTiles database and used as a tile set according to version 1.1 of the MBTiles specification: https://github.com/mapbox/mbtiles-spec
+
+In addition to PNG and JPEG raster tiles, MBTiles can also provide vector tiles using any of the supported [`type`](#type) values. The `type` for an MBTiles data source should match the format of the tile data in the MBTiles database.
+
+Here is an example configuration of an MBTiles source:
+
+```yaml
+mbtiles-source:
+    type: TopoJSON # The source expects TopoJSON tile data.
+    url: data/tileset.mbtiles # The MBTiles file is located relative to the scene file.
+    max_zoom: 16 # Other parameters are applied as usual.
+```
+
 ### optional source parameters
 
 #### `bounds`

--- a/pages/sources.md
+++ b/pages/sources.md
@@ -156,6 +156,8 @@ mbtiles-source:
     max_zoom: 16 # Other parameters are applied as usual.
 ```
 
+If you are developing an Android application that uses an MBTiles file located in external storage, your application will need to [request permissions](https://developer.android.com/training/permissions/index.html) to read the file.
+
 ### optional source parameters
 
 #### `bounds`

--- a/pages/sources.md
+++ b/pages/sources.md
@@ -143,7 +143,7 @@ mapbox:
 
 ##### MBTiles
 
-[[ES-only](https://github.com/tangrams/tangram-es)] If the _URL_ of a data source has a file extension of `.mbtiles` then the specified file will be accessed as an MBTiles database and used as a tile set according to version 1.1 of the MBTiles specification: https://github.com/mapbox/mbtiles-spec
+[[ES-only](https://github.com/tangrams/tangram-es)] If the _URL_ of a data source has a file extension of `.mbtiles` then the specified file will be accessed as an MBTiles database and used as a tile set according to the MBTiles specification (following the proposed [version 2.0](https://github.com/pnorman/mbtiles-spec/blob/2.0/2.0/spec.md)).
 
 In addition to PNG and JPEG raster tiles, MBTiles can also provide vector tiles using any of the supported [`type`](#type) values. The `type` for an MBTiles data source should match the format of the tile data in the MBTiles database.
 


### PR DESCRIPTION
Documents how Tangram ES can load tilesets from MBTiles databases.

Since we load vector tile formats, we don't strictly follow version 1.1 of the spec. Our implementation actually follows the proposed version 2.0 of the spec (https://github.com/mapbox/mbtiles-spec/pull/46). I can update these docs when/if those changes to the spec are merged.

Resolves #192 