### PR TITLE
Add mkdocs config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,2 @@
+site_name: Tangram Docs
+theme: readthedocs


### PR DESCRIPTION
- readthedocs will use this instead of their default mkdocs settings
- allows building the docs site locally with the same settings as readthedocs
- changes theme to 'readthedocs'

New theme:
<img width="615" alt="screen shot 2018-12-07 at 3 32 57 pm" src="https://user-images.githubusercontent.com/3371850/49671537-405fd380-fa36-11e8-800b-ec39bffffd96.png">
