### PR TITLE
fix links to android and ios walkthroughs

### DIFF
--- a/docs/API-Reference/Android-API.md
+++ b/docs/API-Reference/Android-API.md
@@ -1,3 +1,3 @@
-*To learn how to get started with the Tangram Android SDK see the [Android Walkthrough](https://mapzen.com/documentation/tangram/android-walkthrough/).*
+*To learn how to get started with the Tangram Android SDK see the [Android Walkthrough](https://tangrams.readthedocs.io/en/master/Tutorials/android-walkthrough/).*
 
 *To see reference documentation for the SDK, go to the [javadoc](android-sdk/0.11.0/index.html).*

--- a/docs/API-Reference/iOS-API.md
+++ b/docs/API-Reference/iOS-API.md
@@ -1,5 +1,5 @@
 *To see reference documentation for the iOS Framework, go to the [framework documentation](ios-framework/0.11.0/index.html).*
 
-*To learn how to get started with the Tangram iOS framework, see the [iOS Walkthrough](https://mapzen.com/documentation/tangram/iOS-walkthrough/).*
+*To learn how to get started with the Tangram iOS framework, see the [iOS Walkthrough](https://tangrams.readthedocs.io/en/master/Tutorials/iOS-walkthrough/).*
 
 *The last version of the iOS binary framework is available in [CocoaPods](https://cocoapods.org/pods/Tangram-ES).*


### PR DESCRIPTION
The old links linked to mapzen.com which redirects to the landing page of the docs, not the specific articles.